### PR TITLE
Fix to make the compile report work again

### DIFF
--- a/src/lambda/aws_compile_audit_report/app.py
+++ b/src/lambda/aws_compile_audit_report/app.py
@@ -292,7 +292,14 @@ def get_all_evidence_folders_paginated(auditmanager_client, assessment_id):
             )
 
         for folder in resp.get("evidenceFolders", []):
-            yield folder
+            # filter evidence folders by today's date instead of yielding every folder
+            cutoff = datetime.datetime.now(
+                tz=datetime.timezone.utc
+            ) - datetime.timedelta(days=1)
+
+            date = folder.get("date")
+            if date and date > cutoff:
+                yield folder
 
         next_token = resp.get("nextToken")
         if not next_token:


### PR DESCRIPTION
# Description

This fixes the audit report to be generated so that compliancy can be reported to SSC. 
